### PR TITLE
Fix and refactor artifact download for Claude's new API

### DIFF
--- a/background.js
+++ b/background.js
@@ -4,24 +4,23 @@ importScripts("jszip.min.js");
 // Listen for messages from the content script
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.action === "downloadArtifacts") {
-    // Check for artifacts first in the new storage format
+    // Get artifacts from storage based on conversation UUID
     chrome.storage.local.get([`artifacts_${request.uuid}`], (artifactsResult) => {
       const artifacts = artifactsResult[`artifacts_${request.uuid}`];
       
-      // If artifacts are found, proceed with the download
       if (artifacts && artifacts.length > 0) {
         console.log("Found artifacts:", artifacts.length);
         const zip = new JSZip();
         let artifactCount = 0;
         
         // Add each artifact to the ZIP file
-        artifacts.forEach((artifact, index) => {
+        artifacts.forEach((artifact) => {
           const fileName = artifact.file_name;
           const content = artifact.content;
           
-          // Add the file to the ZIP
           zip.file(fileName, content);
           artifactCount++;
+          console.log(`Added artifact: ${fileName}`);
         });
         
         // Generate the ZIP and offer download
@@ -55,167 +54,19 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
           };
           reader.readAsArrayBuffer(content);
         });
+      } else {
+        // No artifacts found
+        chrome.tabs.sendMessage(sender.tab.id, {
+          action: "artifactsProcessed",
+          message: "No artifacts found for this conversation.",
+        });
       }
     });
+    return true; // Keep the message channel open for async response
   }
 });
 
-function processMessage(
-  message,
-  payload,
-  zip,
-  usedNames,
-  artifactCount,
-  useDirectoryStructure,
-  depth = 0,
-) {
-  // Process assistant messages
-  if (message.sender === "assistant" && message.text) {
-    try {
-      const artifacts = extractArtifacts(message.text);
-      artifacts.forEach((artifact, artifactIndex) => {
-        artifactCount++;
-        const fileName = getUniqueFileName(
-          artifact.title,
-          artifact.language,
-          message.index,
-          usedNames,
-          useDirectoryStructure,
-        );
-        zip.file(fileName, artifact.content);
-        console.log(`Added artifact: ${fileName}`);
-      });
-    } catch (error) {
-      console.error(`Error processing message ${message.uuid}:`, error);
-    }
-  }
-
-  // Prevent excessive recursion
-  if (depth > 100) {
-    console.warn(
-      "Maximum recursion depth reached. Stopping message processing.",
-    );
-    return artifactCount;
-  }
-
-  // Find child messages
-  const childMessages = payload.chat_messages.filter(
-    (m) => m.parent_message_uuid === message.uuid,
-  );
-
-  // Process child messages in chronological order
-  childMessages
-    .sort((a, b) => new Date(a.created_at) - new Date(b.created_at))
-    .forEach((childMessage) => {
-      artifactCount = processMessage(
-        childMessage,
-        payload,
-        zip,
-        usedNames,
-        artifactCount,
-        useDirectoryStructure,
-        depth + 1,
-      );
-    });
-
-  return artifactCount;
-}
-
-function extractArtifacts(text) {
-  const artifactRegex = /<antArtifact[^>]*>([\s\S]*?)<\/antArtifact>/g;
-  const artifacts = [];
-  let match;
-
-  while ((match = artifactRegex.exec(text)) !== null) {
-    const fullTag = match[0];
-    const content = match[1];
-
-    const titleMatch = fullTag.match(/title="([^"]*)/);
-    const languageMatch = fullTag.match(/language="([^"]*)/);
-
-    artifacts.push({
-      title: titleMatch ? titleMatch[1] : "Untitled",
-      language: languageMatch ? languageMatch[1] : "txt",
-      content: content.trim(),
-    });
-  }
-
-  return artifacts;
-}
-
-function getUniqueFileName(
-  title,
-  language,
-  messageIndex,
-  usedNames,
-  useDirectoryStructure,
-) {
-  let baseName = title.replace(/[^\w\-._]+/g, "_");
-  let extension = getFileExtension(language);
-
-  let fileName = useDirectoryStructure
-    ? inferDirectoryStructure(baseName, extension)
-    : `${messageIndex + 1}_${baseName}${extension}`;
-  if (usedNames.has(fileName)) {
-    let suffix = "";
-    let suffixCount = 1;
-    while (usedNames.has(fileName)) {
-      suffix = `_${"*".repeat(suffixCount)}`;
-      fileName = useDirectoryStructure
-        ? inferDirectoryStructure(baseName, extension, messageIndex, suffix)
-        : `${messageIndex + 1}_${baseName}${suffix}${extension}`;
-      suffixCount++;
-    }
-  }
-
-  usedNames.add(fileName);
-  return fileName;
-}
-
-function inferDirectoryStructure(
-  baseName,
-  extension,
-  messageIndex = null,
-  suffix = "",
-) {
-  const parts = baseName.split("/");
-  if (parts.length > 1) {
-    const fileName = `${parts.pop()}${suffix}${extension}`;
-    const directory = parts.join("/");
-    return messageIndex !== null
-      ? `${directory}/${messageIndex + 1}_${fileName}`
-      : `${directory}/${fileName}`;
-  }
-  return messageIndex !== null
-    ? `${messageIndex + 1}_${baseName}${suffix}${extension}`
-    : `${baseName}${suffix}${extension}`;
-}
-
-function getFileExtension(language) {
-  const languageToExt = {
-    javascript: ".js",
-    html: ".html",
-    css: ".css",
-    python: ".py",
-    java: ".java",
-    c: ".c",
-    cpp: ".cpp",
-    ruby: ".rb",
-    php: ".php",
-    swift: ".swift",
-    go: ".go",
-    rust: ".rs",
-    typescript: ".ts",
-    shell: ".sh",
-    sql: ".sql",
-    kotlin: ".kt",
-    scala: ".scala",
-    r: ".r",
-    matlab: ".m",
-  };
-  return languageToExt[language.toLowerCase()] || ".txt";
-}
-
+// Convert ArrayBuffer to Base64 for download URL
 function arrayBufferToBase64(buffer) {
   let binary = "";
   const bytes = new Uint8Array(buffer);
@@ -226,28 +77,31 @@ function arrayBufferToBase64(buffer) {
   return btoa(binary);
 }
 
+// Monitor tab updates to add the download button
 chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
   if (changeInfo.url && changeInfo.url.startsWith("https://claude.ai/chat/")) {
     chrome.tabs.sendMessage(tabId, { action: "checkAndAddDownloadButton" });
   }
 });
 
-
+// Listen for artifact data from the docs endpoint
 chrome.webRequest.onBeforeSendHeaders.addListener(
   (obj) => {
     if (!isOwnRequest(obj)) {
       fetchDocs(obj).then((resp) => {
         if (resp && Array.isArray(resp)) {
-          // Get the conversation ID from the URL or the current page
+          // Get the conversation ID from the current tab
           chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
-            const url = tabs[0].url;
-            const match = url.match(/\/chat\/([a-f0-9-]+)/);
-            if (match && match[1]) {
-              const conversationUuid = match[1];
-              console.log("Storing artifacts for conversation:", conversationUuid);
-              chrome.storage.local.set({ 
-                [`artifacts_${conversationUuid}`]: resp 
-              });
+            if (tabs && tabs.length > 0) {
+              const url = tabs[0].url;
+              const match = url.match(/\/chat\/([a-f0-9-]+)/);
+              if (match && match[1]) {
+                const conversationUuid = match[1];
+                console.log("Storing artifacts for conversation:", conversationUuid);
+                chrome.storage.local.set({ 
+                  [`artifacts_${conversationUuid}`]: resp 
+                });
+              }
             }
           });
         }
@@ -258,6 +112,7 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
   ["requestHeaders", "extraHeaders"],
 );
 
+// Check if a request is our own to prevent infinite loops
 function isOwnRequest(obj) {
   return (
     obj.requestHeaders?.some((header) => header.name === "X-Own-Request") ??
@@ -265,6 +120,7 @@ function isOwnRequest(obj) {
   );
 }
 
+// Fetch artifact data from the docs endpoint
 async function fetchDocs(obj) {
   const headers = {};
   obj.requestHeaders.forEach((header) => (headers[header.name] = header.value));


### PR DESCRIPTION
# Fix and refactor artifact download for Claude's new API

## Problem
The extension stopped working entirely because Claude changed how it stores artifacts from embedded message tags to a separate `/docs` endpoint.

## Solution
This PR has two main parts:
1. Add support for Claude's new `/docs` API endpoint to restore download functionality
2. Remove unused message parsing code for cleaner, more maintainable codebase

## Changes
- Added listener for the `/docs` endpoint to capture artifact data
- Store artifacts by conversation UUID in chrome.storage.local
- Simplified artifact download handler
- Removed unused message parsing functions (extractArtifacts, processMessage, etc.)

## Testing
- Tested with Claude 3.7 on March 13, 2025
- Successfully downloads all artifacts from conversations