### PR TITLE
Fix Claude payload fetch, button placement, and current-chat content export

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,98 +1,153 @@
 // background.js
 importScripts("jszip.min.js");
 
+const LOG_PREFIX = "[Claude Artifact Downloader]";
+const CHAT_URL_PATTERN = /^https:\/\/claude\.ai\/chat\/[^/]+/;
+
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-  if (request.action === "downloadArtifacts") {
-    chrome.storage.local.get([`chat_${request.uuid}`], (result) => {
-      const payload = result[`chat_${request.uuid}`];
-      if (!payload) {
-        const msg = "No payload found, try refreshing the page.";
-        chrome.tabs.sendMessage(sender.tab.id, {
-          action: "artifactsProcessed",
-          message: msg,
-        });
-        return;
-      }
+  if (request.action !== "downloadArtifacts") {
+    return false;
+  }
 
-      const chatData = payload;
-      console.log(payload);
-      const zip = new JSZip();
-      let artifactCount = 0;
-      const usedNames = new Set();
+  handleDownloadArtifacts(request, sender)
+    .then((result) => sendResponse({ success: true, ...result }))
+    .catch((err) => sendResponse({ success: false, error: err.message }));
 
-      // Find the most recent root message
-      const mostRecentRootMessage = payload.chat_messages
-        .filter(
-          (message) =>
-            message.parent_message_uuid ===
-            "00000000-0000-4000-8000-000000000000",
-        )
-        .reduce((latest, current) => {
-          return new Date(current.updated_at) > new Date(latest.updated_at)
-            ? current
-            : latest;
-        });
+  return true;
+});
 
-      // Use the directory structure option from the request
-      const useDirectoryStructure = request.useDirectoryStructure;
+function getTabId(sender, request) {
+  return request.tabId ?? sender.tab?.id;
+}
 
-      // Start processing from the most recent root message
-      if (mostRecentRootMessage) {
-        artifactCount = processMessage(
-          mostRecentRootMessage,
-          payload,
-          zip,
-          usedNames,
-          0,
-          useDirectoryStructure,
-        );
-      }
+function notifyTab(tabId, payload) {
+  if (!tabId) {
+    return;
+  }
+  chrome.tabs.sendMessage(tabId, payload, () => {
+    if (chrome.runtime.lastError) {
+      console.warn(LOG_PREFIX, "Could not notify tab:", chrome.runtime.lastError.message);
+    }
+  });
+}
 
-      if (artifactCount === 0) {
-        const msg = "No artifacts found in this conversation.";
-        chrome.tabs.sendMessage(sender.tab.id, {
-          action: "artifactsProcessed",
-          success: true,
-          message: msg,
-        });
-        return;
-      }
+function sanitizeFilename(name) {
+  const sanitized = (name || "claude-artifacts")
+    .replace(/[/\\?%*:|"<>]/g, "_")
+    .replace(/[\x00-\x1f]/g, "")
+    .trim();
+  return sanitized || "claude-artifacts";
+}
 
-      zip.generateAsync({ type: "blob" }).then((content) => {
-        const reader = new FileReader();
-        reader.onload = function (e) {
-          const arrayBuffer = e.target.result;
-          chrome.downloads.download(
-            {
-              url:
-                "data:application/zip;base64," +
-                arrayBufferToBase64(arrayBuffer),
-              filename: `${chatData.name}.zip`,
-              saveAs: true,
-            },
-            (downloadId) => {
-              if (chrome.runtime.lastError) {
-                console.error(chrome.runtime.lastError);
-                chrome.tabs.sendMessage(sender.tab.id, {
-                  action: "artifactsProcessed",
-                  failure: true,
-                  message: "Error downloading artifacts.",
-                });
-              } else {
-                chrome.tabs.sendMessage(sender.tab.id, {
-                  action: "artifactsProcessed",
-                  success: true,
-                  message: `${artifactCount} artifacts downloaded successfully.`,
-                });
-              }
-            },
-          );
-        };
-        reader.readAsArrayBuffer(content);
-      });
+function getStoragePayload(uuid) {
+  return new Promise((resolve) => {
+    chrome.storage.local.get([`chat_${uuid}`], (result) => {
+      resolve(result[`chat_${uuid}`]);
+    });
+  });
+}
+
+async function handleDownloadArtifacts(request, sender) {
+  const tabId = getTabId(sender, request);
+
+  if (!request.uuid) {
+    const msg = "No conversation UUID found.";
+    notifyTab(tabId, { action: "artifactsProcessed", failure: true, message: msg });
+    throw new Error(msg);
+  }
+
+  const payload = await getStoragePayload(request.uuid);
+  if (!payload) {
+    const msg = "No payload found, try refreshing the page.";
+    notifyTab(tabId, { action: "artifactsProcessed", failure: true, message: msg });
+    throw new Error(msg);
+  }
+
+  if (!payload.chat_messages || payload.chat_messages.length === 0) {
+    const msg = "No chat messages found in cached payload.";
+    notifyTab(tabId, { action: "artifactsProcessed", failure: true, message: msg });
+    throw new Error(msg);
+  }
+
+  const chatData = payload;
+  const zip = new JSZip();
+  let artifactCount = 0;
+  const usedNames = new Set();
+
+  const rootMessages = payload.chat_messages.filter(
+    (message) =>
+      message.parent_message_uuid === "00000000-0000-4000-8000-000000000000",
+  );
+
+  let mostRecentRootMessage = null;
+  if (rootMessages.length > 0) {
+    mostRecentRootMessage = rootMessages.reduce((latest, current) => {
+      return new Date(current.updated_at) > new Date(latest.updated_at)
+        ? current
+        : latest;
     });
   }
-});
+
+  const useDirectoryStructure = request.useDirectoryStructure;
+
+  if (mostRecentRootMessage) {
+    artifactCount = processMessage(
+      mostRecentRootMessage,
+      payload,
+      zip,
+      usedNames,
+      0,
+      useDirectoryStructure,
+    );
+  }
+
+  if (artifactCount === 0) {
+    const msg = "No artifacts found in this conversation.";
+    notifyTab(tabId, {
+      action: "artifactsProcessed",
+      success: true,
+      message: msg,
+    });
+    return { message: msg, artifactCount: 0 };
+  }
+
+  try {
+    const base64 = await zip.generateAsync({ type: "base64" });
+    await new Promise((resolve, reject) => {
+      chrome.downloads.download(
+        {
+          url: `data:application/zip;base64,${base64}`,
+          filename: `${sanitizeFilename(chatData.name)}.zip`,
+          saveAs: true,
+        },
+        (downloadId) => {
+          if (chrome.runtime.lastError) {
+            reject(new Error(chrome.runtime.lastError.message));
+          } else {
+            resolve(downloadId);
+          }
+        },
+      );
+    });
+
+    const msg = `${artifactCount} artifacts downloaded successfully.`;
+    notifyTab(tabId, {
+      action: "artifactsProcessed",
+      success: true,
+      message: msg,
+    });
+    return { message: msg, artifactCount };
+  } catch (error) {
+    console.error(LOG_PREFIX, "ZIP download error:", error);
+    const msg = "Error downloading artifacts.";
+    notifyTab(tabId, {
+      action: "artifactsProcessed",
+      failure: true,
+      message: msg,
+    });
+    throw error;
+  }
+}
 
 function processMessage(
   message,
@@ -103,11 +158,10 @@ function processMessage(
   useDirectoryStructure,
   depth = 0,
 ) {
-  // Process assistant messages
   if (message.sender === "assistant" && message.text) {
     try {
       const artifacts = extractArtifacts(message.text);
-      artifacts.forEach((artifact, artifactIndex) => {
+      artifacts.forEach((artifact) => {
         artifactCount++;
         const fileName = getUniqueFileName(
           artifact.title,
@@ -124,7 +178,6 @@ function processMessage(
     }
   }
 
-  // Prevent excessive recursion
   if (depth > 100) {
     console.warn(
       "Maximum recursion depth reached. Stopping message processing.",
@@ -132,12 +185,10 @@ function processMessage(
     return artifactCount;
   }
 
-  // Find child messages
   const childMessages = payload.chat_messages.filter(
     (m) => m.parent_message_uuid === message.uuid,
   );
 
-  // Process child messages in chronological order
   childMessages
     .sort((a, b) => new Date(a.created_at) - new Date(b.created_at))
     .forEach((childMessage) => {
@@ -250,34 +301,45 @@ function getFileExtension(language) {
   return languageToExt[language.toLowerCase()] || ".txt";
 }
 
-function arrayBufferToBase64(buffer) {
-  let binary = "";
-  const bytes = new Uint8Array(buffer);
-  const len = bytes.byteLength;
-  for (let i = 0; i < len; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binary);
-}
-
-chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
-  if (changeInfo.url && changeInfo.url.startsWith("https://claude.ai/chat/")) {
+chrome.tabs.onUpdated.addListener(function (tabId, changeInfo) {
+  if (changeInfo.url && CHAT_URL_PATTERN.test(changeInfo.url)) {
     chrome.tabs.sendMessage(tabId, { action: "checkAndAddDownloadButton" });
   }
 });
+
+const webRequestExtraInfoSpec = ["requestHeaders"];
+if (chrome.webRequest.OnBeforeSendHeadersOptions?.EXTRA_HEADERS) {
+  webRequestExtraInfoSpec.push("extraHeaders");
+}
 
 chrome.webRequest.onBeforeSendHeaders.addListener(
   (obj) => {
     if (isChatRequest(obj) && !isOwnRequest(obj)) {
       fetchChat(obj).then((resp) => {
+        if (!resp) {
+          console.warn(
+            LOG_PREFIX,
+            "fetchChat returned no payload for",
+            obj.url,
+          );
+          return;
+        }
         if (resp.chat_messages && resp.uuid) {
+          console.log(
+            LOG_PREFIX,
+            "Stored chat payload:",
+            resp.uuid,
+            `(${resp.chat_messages.length} messages)`,
+          );
           chrome.storage.local.set({ [`chat_${resp.uuid}`]: resp });
+        } else {
+          console.warn(LOG_PREFIX, "Unusable chat payload:", obj.url, resp);
         }
       });
     }
   },
   { urls: ["https://api.claude.ai/api/*chat_conversations*"] },
-  ["requestHeaders", "extraHeaders"],
+  webRequestExtraInfoSpec,
 );
 
 function isChatRequest(obj) {
@@ -306,7 +368,7 @@ async function fetchChat(obj) {
     if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
     return await response.json();
   } catch (error) {
-    console.error("Fetch error:", error);
+    console.error(LOG_PREFIX, "Fetch error:", error);
     return null;
   }
 }

--- a/background.js
+++ b/background.js
@@ -3,6 +3,38 @@ importScripts("jszip.min.js");
 
 const LOG_PREFIX = "[Claude Artifact Downloader]";
 const CHAT_URL_PATTERN = /^https:\/\/claude\.ai\/chat\/[^/]+/;
+const ORG_API_URLS = [
+  "https://claude.ai/api/organizations",
+  "https://api.claude.ai/api/organizations",
+];
+
+function collectChatOrgIds(data) {
+  const orgs = Array.isArray(data)
+    ? data
+    : data.organizations || data.data || [];
+  return orgs
+    .filter((org) => {
+      const caps = org.capabilities;
+      return !caps || caps.includes("chat");
+    })
+    .map((org) => org.uuid || org.id)
+    .filter(Boolean);
+}
+const API_HOSTS = ["https://claude.ai", "https://api.claude.ai"];
+
+const CONVERSATION_PARAM_SETS = [
+  { tree: "True", rendering_mode: "messages", render_all_tools: "true" },
+  { tree: "True", rendering_mode: "raw" },
+];
+
+function getActiveFetchHeaders(uuid) {
+  return {
+    Accept: "application/json",
+    "X-Own-Request": "true",
+    Referer: `https://claude.ai/chat/${uuid}`,
+    "anthropic-client-platform": "web_claude_ai",
+  };
+}
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.action !== "downloadArtifacts") {
@@ -47,6 +79,99 @@ function getStoragePayload(uuid) {
   });
 }
 
+function getChatFetchMeta(uuid) {
+  return new Promise((resolve) => {
+    chrome.storage.local.get([`chat_meta_${uuid}`], (result) => {
+      resolve(result[`chat_meta_${uuid}`]);
+    });
+  });
+}
+
+function storeChatFetchMeta(uuid, rawUrl) {
+  const orgId = extractOrgIdFromPath(new URL(rawUrl).pathname);
+  const updates = {
+    [`chat_meta_${uuid}`]: { rawUrl, capturedAt: Date.now() },
+  };
+  if (orgId) {
+    updates.last_org_id = orgId;
+  }
+  chrome.storage.local.set(updates);
+}
+
+function extractOrgIdFromPath(pathname) {
+  const match = pathname.match(/\/organizations\/([0-9a-f-]{36})/i);
+  return match ? match[1] : null;
+}
+
+function getLastOrgId() {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(["last_org_id"], (result) => {
+      resolve(result.last_org_id ?? null);
+    });
+  });
+}
+
+function isValidChatPayload(resp) {
+  return !!(
+    resp &&
+    resp.uuid &&
+    Array.isArray(resp.chat_messages) &&
+    resp.chat_messages.length > 0
+  );
+}
+
+async function storeChatPayload(resp) {
+  await new Promise((resolve) => {
+    chrome.storage.local.set({ [`chat_${resp.uuid}`]: resp }, resolve);
+  });
+}
+
+function buildConversationUrls(host, orgId, uuid) {
+  return CONVERSATION_PARAM_SETS.map((params) => {
+    const url = new URL(
+      `/api/organizations/${orgId}/chat_conversations/${uuid}`,
+      host,
+    );
+    for (const [key, value] of Object.entries(params)) {
+      url.searchParams.set(key, value);
+    }
+    return url.toString();
+  });
+}
+
+function parseChatConversationRequest(obj) {
+  if (obj.method !== "GET") {
+    return null;
+  }
+  try {
+    const url = new URL(obj.url);
+    if (url.hostname !== "api.claude.ai" && url.hostname !== "claude.ai") {
+      return null;
+    }
+    if (!url.pathname.includes("chat_conversations")) {
+      return null;
+    }
+    const uuidMatch = url.pathname.match(/chat_conversations\/([0-9a-f-]{36})/i);
+    if (!uuidMatch) {
+      return null;
+    }
+    return {
+      url,
+      uuid: uuidMatch[1],
+      renderingMode: url.searchParams.get("rendering_mode"),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function buildRawConversationUrl(urlString) {
+  const url = new URL(urlString);
+  url.searchParams.set("tree", "True");
+  url.searchParams.set("rendering_mode", "raw");
+  return url.toString();
+}
+
 async function handleDownloadArtifacts(request, sender) {
   const tabId = getTabId(sender, request);
 
@@ -56,9 +181,13 @@ async function handleDownloadArtifacts(request, sender) {
     throw new Error(msg);
   }
 
-  const payload = await getStoragePayload(request.uuid);
+  console.log(LOG_PREFIX, "download requested for", request.uuid);
+  const { payload, error: fetchError } = await ensureChatPayload(
+    request.uuid,
+    tabId,
+  );
   if (!payload) {
-    const msg = "No payload found, try refreshing the page.";
+    const msg = `Could not fetch Claude conversation payload. Open the extension service worker console and check the active-fetch logs. Last error: ${fetchError || "unknown"}`;
     notifyTab(tabId, { action: "artifactsProcessed", failure: true, message: msg });
     throw new Error(msg);
   }
@@ -101,8 +230,34 @@ async function handleDownloadArtifacts(request, sender) {
     );
   }
 
+  if (artifactCount === 0 && tabId) {
+    console.log(
+      LOG_PREFIX,
+      "no export items in cached payload; trying raw-mode supplement",
+    );
+    const rawSupplement = await fetchPayloadViaPageEventBridge(
+      tabId,
+      request.uuid,
+      { rawOnly: true },
+    );
+    if (rawSupplement.payload && mostRecentRootMessage) {
+      artifactCount = processMessage(
+        mostRecentRootMessage,
+        rawSupplement.payload,
+        zip,
+        usedNames,
+        0,
+        useDirectoryStructure,
+      );
+      if (artifactCount > 0) {
+        await storeChatPayload(rawSupplement.payload);
+      }
+    }
+  }
+
   if (artifactCount === 0) {
-    const msg = "No artifacts found in this conversation.";
+    const msg =
+      "No exportable content found (artifacts, pasted text, or attachments).";
     notifyTab(tabId, {
       action: "artifactsProcessed",
       success: true,
@@ -149,6 +304,132 @@ async function handleDownloadArtifacts(request, sender) {
   }
 }
 
+function getMessageText(message) {
+  if (typeof message.text === "string" && message.text.trim()) {
+    return message.text;
+  }
+  if (Array.isArray(message.content)) {
+    return message.content
+      .filter((block) => block.type === "text" && block.text)
+      .map((block) => block.text)
+      .join("\n\n");
+  }
+  return "";
+}
+
+function inferLanguageFromFileType(fileType) {
+  if (!fileType) {
+    return "txt";
+  }
+  const ft = String(fileType).toLowerCase();
+  if (ft.includes("markdown") || ft === "md" || ft.endsWith(".md")) {
+    return "markdown";
+  }
+  if (ft.includes("json")) {
+    return "json";
+  }
+  if (ft.includes("html")) {
+    return "html";
+  }
+  if (ft.includes("python") || ft === "py") {
+    return "python";
+  }
+  if (ft.includes("javascript") || ft === "js") {
+    return "javascript";
+  }
+  return "txt";
+}
+
+function inferPastedTitle(text, sender) {
+  const firstLine = text.trim().split("\n")[0].slice(0, 60);
+  const cleaned = firstLine.replace(/[^\w\-._]+/g, "_").replace(/^_+|_+$/g, "");
+  const prefix = sender === "human" ? "pasted" : "content";
+  return cleaned ? `${prefix}_${cleaned}` : `${prefix}_message`;
+}
+
+function collectExportItems(message) {
+  const items = [];
+  const seen = new Set();
+  const text = getMessageText(message);
+
+  function addItem(item) {
+    const content = item.content?.trim();
+    if (!content) {
+      return;
+    }
+    const key = `${item.title}::${content.slice(0, 120)}`;
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    items.push({ ...item, content });
+  }
+
+  for (const artifact of extractArtifacts(text)) {
+    addItem(artifact);
+  }
+
+  if (Array.isArray(message.content)) {
+    for (const block of message.content) {
+      if (block.type === "thinking") {
+        continue;
+      }
+      if (block.type === "text" && block.text) {
+        for (const artifact of extractArtifacts(block.text)) {
+          addItem(artifact);
+        }
+      }
+      const blockBody =
+        block.text ||
+        block.content ||
+        block.source?.data ||
+        block.document?.content;
+      if (typeof blockBody === "string" && blockBody.length > 100) {
+        if (block.type && block.type !== "text") {
+          addItem({
+            title: block.title || block.name || block.type,
+            language: "txt",
+            content: blockBody,
+          });
+        }
+      }
+      if (block.type === "tool_result" && typeof block.content === "string") {
+        addItem({
+          title: "tool_result",
+          language: "txt",
+          content: block.content,
+        });
+      }
+    }
+  }
+
+  const attachmentSources = [
+    ...(message.attachments || []),
+    ...(message.files || []),
+    ...(message.files_v2 || []),
+  ];
+  for (const att of attachmentSources) {
+    const content = att.extracted_content || att.content;
+    if (typeof content === "string") {
+      addItem({
+        title: att.file_name || att.filename || att.name || "attachment",
+        language: inferLanguageFromFileType(att.file_type || att.mime_type),
+        content,
+      });
+    }
+  }
+
+  if (message.sender === "human" && text.trim().length > 80) {
+    addItem({
+      title: inferPastedTitle(text, "human"),
+      language: "markdown",
+      content: text.trim(),
+    });
+  }
+
+  return items;
+}
+
 function processMessage(
   message,
   payload,
@@ -158,24 +439,22 @@ function processMessage(
   useDirectoryStructure,
   depth = 0,
 ) {
-  if (message.sender === "assistant" && message.text) {
-    try {
-      const artifacts = extractArtifacts(message.text);
-      artifacts.forEach((artifact) => {
-        artifactCount++;
-        const fileName = getUniqueFileName(
-          artifact.title,
-          artifact.language,
-          message.index,
-          usedNames,
-          useDirectoryStructure,
-        );
-        zip.file(fileName, artifact.content);
-        console.log(`Added artifact: ${fileName}`);
-      });
-    } catch (error) {
-      console.error(`Error processing message ${message.uuid}:`, error);
-    }
+  try {
+    const exportItems = collectExportItems(message);
+    exportItems.forEach((item) => {
+      artifactCount++;
+      const fileName = getUniqueFileName(
+        item.title,
+        item.language,
+        message.index,
+        usedNames,
+        useDirectoryStructure,
+      );
+      zip.file(fileName, item.content);
+      console.log(`Added export item: ${fileName}`);
+    });
+  } catch (error) {
+    console.error(`Error processing message ${message.uuid}:`, error);
   }
 
   if (depth > 100) {
@@ -297,6 +576,9 @@ function getFileExtension(language) {
     scala: ".scala",
     r: ".r",
     matlab: ".m",
+    markdown: ".md",
+    md: ".md",
+    txt: ".txt",
   };
   return languageToExt[language.toLowerCase()] || ".txt";
 }
@@ -314,39 +596,66 @@ if (chrome.webRequest.OnBeforeSendHeadersOptions?.EXTRA_HEADERS) {
 
 chrome.webRequest.onBeforeSendHeaders.addListener(
   (obj) => {
-    if (isChatRequest(obj) && !isOwnRequest(obj)) {
-      fetchChat(obj).then((resp) => {
-        if (!resp) {
-          console.warn(
-            LOG_PREFIX,
-            "fetchChat returned no payload for",
-            obj.url,
-          );
-          return;
-        }
-        if (resp.chat_messages && resp.uuid) {
-          console.log(
-            LOG_PREFIX,
-            "Stored chat payload:",
-            resp.uuid,
-            `(${resp.chat_messages.length} messages)`,
-          );
-          chrome.storage.local.set({ [`chat_${resp.uuid}`]: resp });
-        } else {
-          console.warn(LOG_PREFIX, "Unusable chat payload:", obj.url, resp);
-        }
-      });
+    const parsed = parseChatConversationRequest(obj);
+    if (!parsed || isOwnRequest(obj)) {
+      return;
     }
+
+    console.log(LOG_PREFIX, "Saw chat-conversation API request:", obj.url, {
+      uuid: parsed.uuid,
+      rendering_mode: parsed.renderingMode,
+    });
+
+    const rawUrl = buildRawConversationUrl(obj.url);
+    storeChatFetchMeta(parsed.uuid, rawUrl);
+
+    const fetchUrl =
+      parsed.renderingMode === "raw" ? obj.url : rawUrl;
+    if (parsed.renderingMode !== "raw") {
+      console.log(
+        LOG_PREFIX,
+        "No rendering_mode=raw; will try raw URL:",
+        fetchUrl,
+      );
+    }
+
+    console.log(
+      LOG_PREFIX,
+      "Decided to fetch/cache conversation:",
+      parsed.uuid,
+      fetchUrl,
+    );
+
+    fetchChat(fetchUrl, obj.method, obj.requestHeaders).then((resp) => {
+      if (!resp) {
+        console.warn(
+          LOG_PREFIX,
+          "fetchChat returned no payload for",
+          fetchUrl,
+        );
+        return;
+      }
+      if (resp.chat_messages && resp.uuid) {
+        console.log(
+          LOG_PREFIX,
+          "Stored chat payload:",
+          resp.uuid,
+          `(${resp.chat_messages.length} messages)`,
+        );
+        chrome.storage.local.set({ [`chat_${resp.uuid}`]: resp });
+      } else {
+        console.warn(LOG_PREFIX, "Unusable chat payload:", fetchUrl, resp);
+      }
+    });
   },
-  { urls: ["https://api.claude.ai/api/*chat_conversations*"] },
+  {
+    urls: [
+      "https://api.claude.ai/api/*chat_conversations*",
+      "https://claude.ai/api/*chat_conversations*",
+    ],
+  },
   webRequestExtraInfoSpec,
 );
-
-function isChatRequest(obj) {
-  return (
-    obj.url.endsWith("?tree=True&rendering_mode=raw") && obj.method === "GET"
-  );
-}
 
 function isOwnRequest(obj) {
   return (
@@ -355,20 +664,316 @@ function isOwnRequest(obj) {
   );
 }
 
-async function fetchChat(obj) {
-  const headers = {};
-  obj.requestHeaders.forEach((header) => (headers[header.name] = header.value));
+async function fetchChat(url, method, requestHeaders, uuid) {
+  const headers = uuid ? getActiveFetchHeaders(uuid) : { Accept: "application/json" };
+  (requestHeaders ?? []).forEach(
+    (header) => (headers[header.name] = header.value),
+  );
   headers["X-Own-Request"] = "true";
   try {
-    const response = await fetch(obj.url, {
-      method: obj.method,
-      headers: headers,
+    const response = await fetch(url, {
+      method: method ?? "GET",
+      headers,
       credentials: "include",
     });
-    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
     return await response.json();
   } catch (error) {
     console.error(LOG_PREFIX, "Fetch error:", error);
     return null;
   }
+}
+
+async function fetchPayloadFromUrl(url, requestHeaders, uuid) {
+  const resp = await fetchChat(url, "GET", requestHeaders, uuid);
+  if (!resp) {
+    return { payload: null, error: `HTTP or network error for ${url}` };
+  }
+  if (!isValidChatPayload(resp)) {
+    return { payload: null, error: `unusable payload from ${url}` };
+  }
+  return { payload: resp };
+}
+
+async function discoverOrganizationIds() {
+  const orgIds = new Set();
+  const lastOrgId = await getLastOrgId();
+  if (lastOrgId) {
+    orgIds.add(lastOrgId);
+  }
+
+  for (const orgUrl of ORG_API_URLS) {
+    try {
+      const response = await fetch(orgUrl, {
+        method: "GET",
+        credentials: "include",
+        headers: {
+          Accept: "application/json",
+          "X-Own-Request": "true",
+        },
+      });
+      if (!response.ok) {
+        continue;
+      }
+      const data = await response.json();
+      for (const id of collectChatOrgIds(data)) {
+        orgIds.add(id);
+      }
+    } catch (error) {
+      console.warn(LOG_PREFIX, "Organization discovery error:", orgUrl, error);
+    }
+  }
+
+  return [...orgIds];
+}
+
+async function fetchPayloadViaOrgDiscovery(uuid) {
+  const orgIds = await discoverOrganizationIds();
+  if (orgIds.length === 0) {
+    return { payload: null, error: "no organizations discovered" };
+  }
+
+  const errors = [];
+  for (const orgId of orgIds) {
+    for (const host of API_HOSTS) {
+      for (const url of buildConversationUrls(host, orgId, uuid)) {
+        const result = await fetchPayloadFromUrl(url, null, uuid);
+        if (result.payload) {
+          storeChatFetchMeta(uuid, url);
+          return result;
+        }
+        errors.push(result.error);
+      }
+    }
+  }
+
+  return {
+    payload: null,
+    error: errors.join("; ") || "org discovery fetch failed",
+  };
+}
+
+async function fetchPayloadViaPageEventBridge(tabId, uuid, options = {}) {
+  const rawOnly = options.rawOnly === true;
+  try {
+    const tab = await chrome.tabs.get(tabId);
+    if (!CHAT_URL_PATTERN.test(tab.url || "")) {
+      return {
+        payload: null,
+        error: `tab is not a Claude chat page: ${tab.url || "unknown"}`,
+      };
+    }
+
+    const result = await new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error("page fetch timed out after 30s"));
+      }, 30000);
+
+      chrome.tabs.sendMessage(
+        tabId,
+        { action: "listenForPayload", uuid },
+        (response) => {
+          clearTimeout(timeout);
+          if (chrome.runtime.lastError) {
+            reject(new Error(chrome.runtime.lastError.message));
+            return;
+          }
+          resolve(response);
+        },
+      );
+
+      chrome.scripting
+        .executeScript({
+          target: { tabId },
+          world: "MAIN",
+          func: (convUuid, onlyRaw) => {
+            return (async () => {
+              const eventName = `cad-payload-${convUuid}`;
+
+              function dispatch(detail) {
+                document.dispatchEvent(
+                  new CustomEvent(eventName, { detail }),
+                );
+              }
+
+              function chatOrgs(data) {
+                const orgs = Array.isArray(data)
+                  ? data
+                  : data.organizations || data.data || [];
+                return orgs
+                  .filter((org) => {
+                    const caps = org.capabilities;
+                    return !caps || caps.includes("chat");
+                  })
+                  .map((org) => org.uuid || org.id)
+                  .filter(Boolean);
+              }
+
+              async function discoverOrgIds() {
+                const ids = [];
+                try {
+                  const response = await fetch("/api/organizations", {
+                    credentials: "include",
+                    headers: { Accept: "application/json" },
+                  });
+                  if (response.ok) {
+                    ids.push(...chatOrgs(await response.json()));
+                  }
+                } catch {
+                  // ignore
+                }
+                return [...new Set(ids)];
+              }
+
+              const paramSets = onlyRaw
+                ? [{ tree: "True", rendering_mode: "raw" }]
+                : [
+                    {
+                      tree: "True",
+                      rendering_mode: "messages",
+                      render_all_tools: "true",
+                    },
+                    { tree: "True", rendering_mode: "raw" },
+                  ];
+              const orgIds = await discoverOrgIds();
+              const errors = [];
+              if (!orgIds.length) {
+                dispatch({
+                  payload: null,
+                  error: "no chat-capable organizations found in page context",
+                  orgCount: 0,
+                });
+                return;
+              }
+
+              for (const orgId of orgIds) {
+                for (const ps of paramSets) {
+                  const query = new URLSearchParams(ps).toString();
+                  const path = `/api/organizations/${orgId}/chat_conversations/${convUuid}?${query}`;
+                  const absoluteUrl = `https://claude.ai${path}`;
+                  try {
+                    const response = await fetch(path, {
+                      credentials: "include",
+                      headers: {
+                        Accept: "application/json",
+                        Referer: `https://claude.ai/chat/${convUuid}`,
+                        "anthropic-client-platform": "web_claude_ai",
+                      },
+                    });
+                    if (!response.ok) {
+                      errors.push(`HTTP ${response.status} for ${path}`);
+                      continue;
+                    }
+                    const json = await response.json();
+                    if (json?.uuid && json?.chat_messages?.length) {
+                      dispatch({
+                        payload: json,
+                        rawUrl: absoluteUrl,
+                        orgCount: orgIds.length,
+                        messageCount: json.chat_messages.length,
+                      });
+                      return;
+                    }
+                    errors.push(`unusable payload from ${path}`);
+                  } catch (error) {
+                    errors.push(`${error.message} (${path})`);
+                  }
+                }
+              }
+
+              dispatch({
+                payload: null,
+                error: errors.join("; ") || "all page fetches failed",
+                orgCount: orgIds.length,
+              });
+            })();
+          },
+          args: [uuid, rawOnly],
+        })
+        .catch((error) => {
+          clearTimeout(timeout);
+          reject(error);
+        });
+    });
+
+    if (isValidChatPayload(result?.payload)) {
+      if (result.rawUrl) {
+        storeChatFetchMeta(uuid, result.rawUrl);
+      }
+      return { payload: result.payload };
+    }
+
+    return {
+      payload: null,
+      error: result?.error || "page event returned no valid payload",
+    };
+  } catch (error) {
+    return { payload: null, error: error.message };
+  }
+}
+
+async function ensureChatPayload(uuid, tabId) {
+  const cached = await getStoragePayload(uuid);
+  if (isValidChatPayload(cached)) {
+    console.log(LOG_PREFIX, "cache hit for", uuid);
+    return { payload: cached };
+  }
+
+  console.log(LOG_PREFIX, "cache miss for", uuid, "; attempting active fetch");
+  const errors = [];
+
+  if (tabId) {
+    console.log(LOG_PREFIX, "trying page-context fetch ...");
+    const pageResult = await fetchPayloadViaPageEventBridge(tabId, uuid);
+    if (pageResult.payload) {
+      await storeChatPayload(pageResult.payload);
+      console.log(
+        LOG_PREFIX,
+        "active fetch succeeded:",
+        uuid,
+        `(${pageResult.payload.chat_messages.length} messages)`,
+      );
+      return { payload: pageResult.payload };
+    }
+    errors.push(pageResult.error || "page-context fetch failed");
+  } else {
+    errors.push("no tab id for page-context fetch");
+  }
+
+  const meta = await getChatFetchMeta(uuid);
+  if (meta?.rawUrl) {
+    console.log(LOG_PREFIX, "trying stored raw URL ...", meta.rawUrl);
+    const storedResult = await fetchPayloadFromUrl(meta.rawUrl, null, uuid);
+    if (storedResult.payload) {
+      await storeChatPayload(storedResult.payload);
+      console.log(
+        LOG_PREFIX,
+        "active fetch succeeded:",
+        uuid,
+        `(${storedResult.payload.chat_messages.length} messages)`,
+      );
+      return { payload: storedResult.payload };
+    }
+    errors.push(storedResult.error || "stored raw URL failed");
+  }
+
+  console.log(LOG_PREFIX, "trying organization discovery ...");
+  const orgResult = await fetchPayloadViaOrgDiscovery(uuid);
+  if (orgResult.payload) {
+    await storeChatPayload(orgResult.payload);
+    console.log(
+      LOG_PREFIX,
+      "active fetch succeeded:",
+      uuid,
+      `(${orgResult.payload.chat_messages.length} messages)`,
+    );
+    return { payload: orgResult.payload };
+  }
+  errors.push(orgResult.error || "organization discovery failed");
+
+  const reason = errors.filter(Boolean).join("; ");
+  console.log(LOG_PREFIX, "active fetch failed:", reason);
+  return { payload: null, error: reason || "unknown" };
 }

--- a/content.js
+++ b/content.js
@@ -1,55 +1,93 @@
-function addDownloadButton() {
-  let buttonContainer = document.querySelector(
+const LOG_PREFIX = "[Claude Artifact Downloader]";
+const CHAT_UUID_PATTERN = /\/chat\/([0-9a-f-]{36})/i;
+const CHAT_PAGE_PATTERN = /^https:\/\/claude\.ai\/chat\/[^/]+/i;
+
+function extractChatUuid(url) {
+  const match = url.match(CHAT_UUID_PATTERN);
+  return match ? match[1] : null;
+}
+
+function isChatPage(url) {
+  return CHAT_PAGE_PATTERN.test(url);
+}
+
+function findButtonContainer() {
+  const selectors = [
     ".flex.min-w-0.items-center.max-md\\:text-sm",
-  );
+    "header .flex.items-center",
+    "header [class*='flex'][class*='items-center']",
+  ];
+
+  for (const selector of selectors) {
+    const container = document.querySelector(selector);
+    if (container) {
+      return container;
+    }
+  }
+
+  const shareButton = Array.from(
+    document.querySelectorAll("header button, header a"),
+  ).find((el) => el.textContent.trim().toLowerCase().includes("share"));
+
+  if (shareButton) {
+    return (
+      shareButton.closest(".flex.items-center") ||
+      shareButton.parentElement
+    );
+  }
+
+  const header = document.querySelector("header");
+  if (header) {
+    return header.querySelector(".flex.items-center") || header;
+  }
+
+  return null;
+}
+
+function addDownloadButton() {
+  const buttonContainer = findButtonContainer();
 
   if (
     buttonContainer &&
     !buttonContainer.querySelector(".claude-download-button")
   ) {
-    let faLink = document.createElement("link");
-    faLink.rel = "stylesheet";
-    faLink.href =
-      "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css";
-    document.head.appendChild(faLink);
-
-    let downloadContainer = document.createElement("div");
+    const downloadContainer = document.createElement("div");
     downloadContainer.className =
       "claude-download-container ml-1 flex items-center";
 
-    let downloadButton = createButton(
-      "download",
-      "Download artifacts",
-      "downloadArtifacts",
-    );
-
-    let optionsDropdown = createOptionsDropdown();
+    const downloadButton = createButton("Download artifacts");
+    const optionsDropdown = createOptionsDropdown();
 
     downloadContainer.appendChild(optionsDropdown);
     downloadContainer.appendChild(downloadButton);
     buttonContainer.appendChild(downloadContainer);
+    console.log(LOG_PREFIX, "button injected successfully");
+    return true;
   }
+
+  return false;
 }
 
-function createButton(icon, text, onClick) {
-  let button = document.createElement("button");
+function createButton(text) {
+  const button = document.createElement("button");
   button.className =
     "claude-download-button ml-1 flex items-center rounded-md bg-gray-100 py-1 px-3 text-sm font-medium text-gray-800 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2";
-  button.innerHTML = `<i class="fa fa-${icon} mr-2"></i>${text}`;
-  button.onclick = window[onClick];
+  button.type = "button";
+  button.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right:6px"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>${text}`;
+  button.addEventListener("click", downloadArtifacts);
   return button;
 }
 
 function createOptionsDropdown() {
-  let select = document.createElement("select");
+  const select = document.createElement("select");
   select.className =
     "claude-download-options rounded-md bg-gray-100 py-1 px-2 text-sm font-medium text-gray-800 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2";
 
-  let flatOption = document.createElement("option");
+  const flatOption = document.createElement("option");
   flatOption.value = "flat";
   flatOption.textContent = "Flat structure";
 
-  let structuredOption = document.createElement("option");
+  const structuredOption = document.createElement("option");
   structuredOption.value = "structured";
   structuredOption.textContent = "Inferred structure";
 
@@ -60,10 +98,15 @@ function createOptionsDropdown() {
 }
 
 function downloadArtifacts() {
-  const url = new URL(window.location.href);
-  const uuid = url.pathname.split("/").pop();
+  const uuid = extractChatUuid(window.location.href);
+  if (!uuid) {
+    createBanner("No conversation UUID found in URL.", "error", 3000);
+    return;
+  }
+
   const optionsDropdown = document.querySelector(".claude-download-options");
-  const useDirectoryStructure = optionsDropdown.value === "structured";
+  const useDirectoryStructure = optionsDropdown?.value === "structured";
+
   chrome.runtime.sendMessage({
     action: "downloadArtifacts",
     uuid: uuid,
@@ -71,40 +114,82 @@ function downloadArtifacts() {
   });
 }
 
-function checkAndAddShareButtons() {
-  if (window.location.href.startsWith("https://claude.ai/chat/")) {
-    const maxAttempts = 15;
-    let attempts = 0;
+let domObserver = null;
 
-    function tryAddButtons() {
-      if (attempts < maxAttempts) {
-        addDownloadButton();
-        if (!document.querySelector(".claude-download-button")) {
-          attempts++;
-          setTimeout(tryAddButtons, 1000);
-        }
-      } else {
-        console.log("Failed to add share buttons after maximum attempts");
-      }
-    }
-    tryAddButtons();
+function startDomObserver() {
+  if (domObserver) {
+    return;
   }
+
+  domObserver = new MutationObserver(() => {
+    if (addDownloadButton()) {
+      domObserver.disconnect();
+      domObserver = null;
+    }
+  });
+
+  domObserver.observe(document.body, { childList: true, subtree: true });
+
+  setTimeout(() => {
+    if (domObserver) {
+      domObserver.disconnect();
+      domObserver = null;
+      console.warn(LOG_PREFIX, "MutationObserver timed out without finding container");
+    }
+  }, 30000);
 }
 
-// for already cached pages
+function checkAndAddShareButtons() {
+  if (!isChatPage(window.location.href)) {
+    console.log(LOG_PREFIX, "not a chat page, skipping button injection");
+    return;
+  }
+
+  const maxAttempts = 15;
+  let attempts = 0;
+
+  function tryAddButtons() {
+    if (document.querySelector(".claude-download-button")) {
+      return;
+    }
+
+    attempts++;
+    console.log(
+      LOG_PREFIX,
+      `attempting button injection (attempt ${attempts}/${maxAttempts})`,
+    );
+
+    if (addDownloadButton()) {
+      return;
+    }
+
+    if (attempts < maxAttempts) {
+      setTimeout(tryAddButtons, 1000);
+    } else {
+      console.warn(
+        LOG_PREFIX,
+        `container not found after ${maxAttempts} attempts, starting MutationObserver`,
+      );
+      startDomObserver();
+    }
+  }
+
+  tryAddButtons();
+}
+
+console.log(LOG_PREFIX, "content script loaded on", window.location.href);
 checkAndAddShareButtons();
 
-// Listen for messages from the background script
-chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((request) => {
   if (request.action === "artifactsProcessed") {
     if (request.success) {
       createBanner(request.message, "success", 1000);
     } else if (request.failure) {
-      createBanner(request.message, "error", 1000);
+      createBanner(request.message, "error", 3000);
+    } else if (request.message) {
+      createBanner(request.message, "error", 3000);
     }
   } else if (request.action === "checkAndAddDownloadButton") {
-    // Observe DOM changes to add the button when the container is available
     checkAndAddShareButtons();
   }
-  return true;
 });

--- a/content.js
+++ b/content.js
@@ -11,67 +11,55 @@ function isChatPage(url) {
   return CHAT_PAGE_PATTERN.test(url);
 }
 
-function findButtonContainer() {
-  const selectors = [
-    ".flex.min-w-0.items-center.max-md\\:text-sm",
-    "header .flex.items-center",
-    "header [class*='flex'][class*='items-center']",
-  ];
+function createDownloadContainer() {
+  const downloadContainer = document.createElement("div");
+  downloadContainer.className =
+    "claude-download-container flex items-center gap-2 shrink-0";
+  downloadContainer.setAttribute("data-claude-downloader", "true");
 
-  for (const selector of selectors) {
-    const container = document.querySelector(selector);
-    if (container) {
-      return container;
-    }
+  const downloadButton = createButton("Download artifacts");
+  const optionsDropdown = createOptionsDropdown();
+
+  downloadContainer.appendChild(optionsDropdown);
+  downloadContainer.appendChild(downloadButton);
+  return downloadContainer;
+}
+
+function injectFloatingButton() {
+  if (document.querySelector(".claude-download-button")) {
+    return false;
   }
 
-  const shareButton = Array.from(
-    document.querySelectorAll("header button, header a"),
-  ).find((el) => el.textContent.trim().toLowerCase().includes("share"));
+  const downloadContainer = createDownloadContainer();
+  downloadContainer.style.cssText =
+    "position: fixed; bottom: 88px; right: 16px; z-index: 40; display: flex; align-items: center; gap: 8px; pointer-events: auto;";
 
-  if (shareButton) {
-    return (
-      shareButton.closest(".flex.items-center") ||
-      shareButton.parentElement
-    );
-  }
-
-  const header = document.querySelector("header");
-  if (header) {
-    return header.querySelector(".flex.items-center") || header;
-  }
-
-  return null;
+  document.body.appendChild(downloadContainer);
+  console.log(
+    LOG_PREFIX,
+    "button injected successfully (floating, bottom-right)",
+  );
+  return true;
 }
 
 function addDownloadButton() {
-  const buttonContainer = findButtonContainer();
+  if (document.querySelector(".claude-download-button")) {
+    console.log(LOG_PREFIX, "injection skipped, button already exists");
+    return false;
+  }
 
-  if (
-    buttonContainer &&
-    !buttonContainer.querySelector(".claude-download-button")
-  ) {
-    const downloadContainer = document.createElement("div");
-    downloadContainer.className =
-      "claude-download-container ml-1 flex items-center";
-
-    const downloadButton = createButton("Download artifacts");
-    const optionsDropdown = createOptionsDropdown();
-
-    downloadContainer.appendChild(optionsDropdown);
-    downloadContainer.appendChild(downloadButton);
-    buttonContainer.appendChild(downloadContainer);
-    console.log(LOG_PREFIX, "button injected successfully");
+  if (injectFloatingButton()) {
     return true;
   }
 
+  console.warn(LOG_PREFIX, "no safe insertion target found");
   return false;
 }
 
 function createButton(text) {
   const button = document.createElement("button");
   button.className =
-    "claude-download-button ml-1 flex items-center rounded-md bg-gray-100 py-1 px-3 text-sm font-medium text-gray-800 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2";
+    "claude-download-button flex items-center rounded-md bg-gray-100 py-1 px-3 text-sm font-medium text-gray-800 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 shadow-md";
   button.type = "button";
   button.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right:6px"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>${text}`;
   button.addEventListener("click", downloadArtifacts);
@@ -81,7 +69,7 @@ function createButton(text) {
 function createOptionsDropdown() {
   const select = document.createElement("select");
   select.className =
-    "claude-download-options rounded-md bg-gray-100 py-1 px-2 text-sm font-medium text-gray-800 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2";
+    "claude-download-options rounded-md bg-gray-100 py-1 px-2 text-sm font-medium text-gray-800 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 shadow-md";
 
   const flatOption = document.createElement("option");
   flatOption.value = "flat";
@@ -104,14 +92,30 @@ function downloadArtifacts() {
     return;
   }
 
+  console.log(LOG_PREFIX, "export requested for", uuid);
   const optionsDropdown = document.querySelector(".claude-download-options");
   const useDirectoryStructure = optionsDropdown?.value === "structured";
 
-  chrome.runtime.sendMessage({
-    action: "downloadArtifacts",
-    uuid: uuid,
-    useDirectoryStructure: useDirectoryStructure,
-  });
+  chrome.runtime.sendMessage(
+    {
+      action: "downloadArtifacts",
+      uuid: uuid,
+      useDirectoryStructure: useDirectoryStructure,
+    },
+    (response) => {
+      if (chrome.runtime.lastError) {
+        const msg = chrome.runtime.lastError.message;
+        console.log(LOG_PREFIX, "export failure:", msg);
+        createBanner(msg, "error", 3000);
+        return;
+      }
+      if (response?.success) {
+        console.log(LOG_PREFIX, "export success:", response.message);
+      } else if (response?.error) {
+        console.log(LOG_PREFIX, "export failure:", response.error);
+      }
+    },
+  );
 }
 
 let domObserver = null;
@@ -134,7 +138,10 @@ function startDomObserver() {
     if (domObserver) {
       domObserver.disconnect();
       domObserver = null;
-      console.warn(LOG_PREFIX, "MutationObserver timed out without finding container");
+      console.warn(
+        LOG_PREFIX,
+        "MutationObserver timed out without finding container",
+      );
     }
   }, 30000);
 }
@@ -145,11 +152,17 @@ function checkAndAddShareButtons() {
     return;
   }
 
+  const uuid = extractChatUuid(window.location.href);
+  if (uuid) {
+    console.log(LOG_PREFIX, "extracted conversation UUID from URL:", uuid);
+  }
+
   const maxAttempts = 15;
   let attempts = 0;
 
   function tryAddButtons() {
     if (document.querySelector(".claude-download-button")) {
+      console.log(LOG_PREFIX, "injection skipped, button already exists");
       return;
     }
 
@@ -180,13 +193,33 @@ function checkAndAddShareButtons() {
 console.log(LOG_PREFIX, "content script loaded on", window.location.href);
 checkAndAddShareButtons();
 
-chrome.runtime.onMessage.addListener((request) => {
+chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
+  if (request.action === "listenForPayload") {
+    const eventName = `cad-payload-${request.uuid}`;
+    console.log(LOG_PREFIX, "listening for page payload event:", eventName);
+    document.addEventListener(
+      eventName,
+      (event) => {
+        const detail = event.detail ?? {
+          payload: null,
+          error: "empty page payload event",
+        };
+        sendResponse(detail);
+      },
+      { once: true },
+    );
+    return true;
+  }
+
   if (request.action === "artifactsProcessed") {
     if (request.success) {
+      console.log(LOG_PREFIX, "export success:", request.message);
       createBanner(request.message, "success", 1000);
     } else if (request.failure) {
+      console.log(LOG_PREFIX, "export failure:", request.message);
       createBanner(request.message, "error", 3000);
     } else if (request.message) {
+      console.log(LOG_PREFIX, "export failure:", request.message);
       createBanner(request.message, "error", 3000);
     }
   } else if (request.action === "checkAndAddDownloadButton") {

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,8 @@
     "tabs",
     "downloads",
     "storage",
-    "webRequest"
+    "webRequest",
+    "scripting"
   ],
   "host_permissions": [
     "https://claude.ai/*",

--- a/manifest.json
+++ b/manifest.json
@@ -3,16 +3,33 @@
   "name": "Claude Artifact Downloader",
   "version": "1.0",
   "description": "Download artifacts from Claude chat conversations as a ZIP file",
-  "permissions": ["tabs", "downloads", "storage", "webRequest"],
-  "host_permissions": ["https://claude.ai/*", "https://api.claude.ai/*"],
+  "permissions": [
+    "tabs",
+    "downloads",
+    "storage",
+    "webRequest"
+  ],
+  "host_permissions": [
+    "https://claude.ai/*",
+    "https://api.claude.ai/*"
+  ],
   "background": {
     "service_worker": "background.js"
   },
   "content_scripts": [
     {
       "run_at": "document_end",
-      "matches": ["https://claude.ai/*"],
-      "js": ["banner.js", "content.js"]
+      "matches": [
+        "https://claude.ai/*"
+      ],
+      "js": [
+        "banner.js",
+        "content.js"
+      ]
     }
-  ]
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Export Claude artifacts"
+  }
 }

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 12px;
+        min-width: 220px;
+      }
+      select {
+        width: 100%;
+        margin-bottom: 8px;
+        padding: 6px;
+        font-size: 13px;
+      }
+      button {
+        width: 100%;
+        padding: 8px;
+        font-size: 13px;
+        cursor: pointer;
+        background: #f3f4f6;
+        border: 1px solid #d1d5db;
+        border-radius: 6px;
+      }
+      button:hover {
+        background: #e5e7eb;
+      }
+    </style>
+  </head>
+  <body>
+    <select id="structure">
+      <option value="flat">Flat structure</option>
+      <option value="structured">Inferred structure</option>
+    </select>
+    <button id="export">Export current chat</button>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,23 @@
+const CHAT_UUID_PATTERN = /\/chat\/([0-9a-f-]{36})/i;
+
+document.getElementById("export").addEventListener("click", async () => {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  const uuid = tab?.url?.match(CHAT_UUID_PATTERN)?.[1];
+
+  if (!uuid) {
+    window.close();
+    return;
+  }
+
+  const useDirectoryStructure =
+    document.getElementById("structure").value === "structured";
+
+  chrome.runtime.sendMessage({
+    action: "downloadArtifacts",
+    uuid: uuid,
+    tabId: tab.id,
+    useDirectoryStructure: useDirectoryStructure,
+  });
+
+  window.close();
+});


### PR DESCRIPTION
## Summary

- Fixes async message-channel failures
- Adds active current-chat payload fetch instead of relying only on passive cache
- Avoids Share button overlap with safer export control placement
- Exports pasted human messages and content blocks in addition to classic Claude artifacts
- Keeps all processing local and only fetches Claude's own API using the user's session

## Test plan

- [ ] Reload the extension in `chrome://extensions`
- [ ] Open a live `claude.ai/chat/<uuid>` conversation without waiting for background cache
- [ ] Click the floating download button (or use the popup) and confirm the ZIP downloads
- [ ] Verify the ZIP contains artifact files, pasted message `.md` files, and any attachments from the conversation
- [ ] Confirm the download button does not overlap the Share control